### PR TITLE
feat: auto-checkpoint on task pass + restore-last + wp-save skill

### DIFF
--- a/cmd/wp-train/checkpoint.go
+++ b/cmd/wp-train/checkpoint.go
@@ -11,9 +11,12 @@ import (
 
 func cmdCheckpoint(args []string) {
 	if len(args) < 1 {
-		jprintln(map[string]any{"status": "error", "message": "usage: wp-train checkpoint <save|restore|list> [name]"})
+		jprintln(map[string]any{"status": "error", "message": "usage: wp-train checkpoint <save|restore|restore-last|list> [name]"})
 		return
 	}
+
+	// Always operate on the current task's site
+	switchToCurrentTaskSite()
 
 	action := args[0]
 	name := "default"
@@ -28,15 +31,18 @@ func cmdCheckpoint(args []string) {
 	case "restore":
 		doCheckpointRestore(name)
 		jprintln(map[string]any{"status": "ok", "action": "restore", "name": name})
+	case "restore-last":
+		doCheckpointRestoreLast()
 	case "list":
 		doCheckpointList()
 	default:
-		jprintln(map[string]any{"status": "error", "message": "unknown action: " + action + " (save|restore|list)"})
+		jprintln(map[string]any{"status": "error", "message": "unknown action: " + action + " (save|restore|restore-last|list)"})
 	}
 }
 
 func checkpointDir() string {
-	d := filepath.Join(trainingDir, "checkpoints")
+	profile := profileForPort(sitePort)
+	d := filepath.Join(trainingDir, "checkpoints", profile)
 	os.MkdirAll(d, 0755)
 	return d
 }
@@ -125,32 +131,46 @@ func doCheckpointRestore(name string) {
 	log("Checkpoint '" + name + "' restored")
 }
 
-func doCheckpointList() {
-	dir := checkpointDir()
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		jprintln(map[string]any{"status": "ok", "checkpoints": []string{}})
+func doCheckpointRestoreLast() {
+	dir := filepath.Join(checkpointDir(), "latest")
+	if !fileExists(dir) {
+		jprintln(map[string]any{"status": "error", "message": "no checkpoint found for profile: " + profileForPort(sitePort) + " — complete at least one task first"})
 		return
 	}
+	doCheckpointRestore("latest")
+	jprintln(map[string]any{"status": "ok", "action": "restore-last", "profile": profileForPort(sitePort)})
+}
 
-	var checkpoints []map[string]any
-	for _, e := range entries {
-		if !e.IsDir() {
+func doCheckpointList() {
+	baseDir := filepath.Join(trainingDir, "checkpoints")
+	profiles := []string{"main", "elementor", "zeroy"}
+
+	allCheckpoints := map[string][]map[string]any{}
+	for _, profile := range profiles {
+		dir := filepath.Join(baseDir, profile)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
 			continue
 		}
-		info, _ := e.Info()
-		cp := map[string]any{
-			"name": e.Name(),
+		var cps []map[string]any
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			info, _ := e.Info()
+			cp := map[string]any{"name": e.Name()}
+			if info != nil {
+				cp["created_at"] = info.ModTime().Format("2006-01-02 15:04:05")
+			}
+			cpDir := filepath.Join(dir, e.Name())
+			cp["has_db"] = fileExists(filepath.Join(cpDir, "db.sqlite")) || fileExists(filepath.Join(cpDir, "db.sql"))
+			cp["has_config"] = fileExists(filepath.Join(cpDir, "wp-config.php"))
+			cps = append(cps, cp)
 		}
-		if info != nil {
-			cp["created_at"] = info.ModTime().Format("2006-01-02 15:04:05")
+		if len(cps) > 0 {
+			allCheckpoints[profile] = cps
 		}
-		// Check what's in the checkpoint
-		cpDir := filepath.Join(dir, e.Name())
-		cp["has_db"] = fileExists(filepath.Join(cpDir, "db.sql"))
-		cp["has_config"] = fileExists(filepath.Join(cpDir, "wp-config.php"))
-		checkpoints = append(checkpoints, cp)
 	}
 
-	jprintln(map[string]any{"status": "ok", "checkpoints": checkpoints})
+	jprintln(map[string]any{"status": "ok", "checkpoints": allCheckpoints})
 }

--- a/cmd/wp-train/commands.go
+++ b/cmd/wp-train/commands.go
@@ -14,10 +14,21 @@ import (
 // ── init ─────────────────────────────────────────────────────────────────────
 
 func cmdInit() {
-	// Delete existing training site if found
-	if sitePort != defaultPort || fileExists(filepath.Join(locwpBase, "wordpress")) {
-		log("Deleting existing site on port " + sitePort + "...")
-		shell("locwp delete " + sitePort)
+	// Delete existing builder sites before resetting
+	sm := loadSiteMap()
+	if sm.Elementor != nil {
+		log("Deleting elementor site on port " + *sm.Elementor + "...")
+		shell("locwp delete " + *sm.Elementor)
+	}
+	if sm.Zeroy != nil {
+		log("Deleting zeroy site on port " + *sm.Zeroy + "...")
+		shell("locwp delete " + *sm.Zeroy)
+	}
+
+	// Delete existing main training site if found
+	if mainPort != defaultPort || fileExists(filepath.Join(locwpBase, "wordpress")) {
+		log("Deleting existing site on port " + mainPort + "...")
+		shell("locwp delete " + mainPort)
 	}
 
 	log("Creating new site...")
@@ -25,21 +36,7 @@ func cmdInit() {
 	if err != nil {
 		fatal("locwp add failed: " + out)
 	}
-	// Parse port from locwp add output (e.g., "Site created at http://localhost:10001")
-	port := ""
-	for _, line := range strings.Split(out, "\n") {
-		if idx := strings.Index(line, "localhost:"); idx >= 0 {
-			rest := line[idx+len("localhost:"):]
-			for _, c := range rest {
-				if c >= '0' && c <= '9' {
-					port += string(c)
-				} else {
-					break
-				}
-			}
-			break
-		}
-	}
+	port := parsePort(out)
 	if port == "" {
 		// Fallback: find the newest site directory
 		entries, _ := os.ReadDir(filepath.Join(homeDir, ".locwp", "sites"))
@@ -54,8 +51,9 @@ func cmdInit() {
 		fatal("could not determine site port from locwp add output")
 	}
 
-	sitePort = port
-	setSitePaths(port)
+	mainPort = port
+	setTrainingPaths(port)
+	switchSite(port)
 
 	log("Installing Classic Editor...")
 	wp("plugin install classic-editor --activate")
@@ -76,6 +74,9 @@ func cmdInit() {
 	db := openDB()
 	db.Exec("INSERT INTO sessions (started_at) VALUES (?)", nowISO())
 	db.Close()
+
+	// Initialize sites.json with main site only (builder sites created on demand)
+	saveSiteMap(SiteMap{Main: port})
 
 	// Clean old progress.json
 	os.Remove(filepath.Join(trainingDir, "progress.json"))
@@ -187,6 +188,7 @@ func cmdNext(args []string) {
 		"hints":        selectedTask.Hints,
 		"on_pass_note": selectedTask.OnPassNote,
 		"verify":       selectedTask.Verify,
+		"site_profile": selectedTask.SiteProfile,
 	}
 	if selectedTask.Chain != "" {
 		record["chain"] = selectedTask.Chain
@@ -194,6 +196,18 @@ func cmdNext(args []string) {
 	}
 	recordJSON, _ := json.Marshal(record)
 	db.Exec("INSERT OR REPLACE INTO current_task (id, task_json, issued_at) VALUES (1, ?, ?)", string(recordJSON), nowISO())
+
+	// Ensure builder site exists (forks from main on first use)
+	activePort := mainPort
+	if selectedTask.SiteProfile != "" && selectedTask.SiteProfile != "main" {
+		port, err := ensureBuilderSite(selectedTask.SiteProfile)
+		if err != nil {
+			jprintln(map[string]any{"status": "error", "message": "failed to create builder site: " + err.Error()})
+			return
+		}
+		activePort = port
+	}
+	siteURL := fmt.Sprintf("http://localhost:%s", activePort)
 
 	// Output without verify, with context
 	mastered := listMastered(db)
@@ -209,6 +223,7 @@ func cmdNext(args []string) {
 		"description":  selectedTask.Description,
 		"hints":        selectedTask.Hints,
 		"on_pass_note": selectedTask.OnPassNote,
+		"site_url":     siteURL,
 		"context": map[string]any{
 			"current_category": currentCategory,
 			"topics_mastered":  mastered,
@@ -350,6 +365,17 @@ func cmdVerify() {
 	var task map[string]any
 	json.Unmarshal([]byte(taskJSON.String), &task)
 
+	// Switch to the task's site (builder sites use a different port)
+	profile := str(task["site_profile"])
+	if profile != "" && profile != "main" {
+		port := portForProfile(profile)
+		if port == "" {
+			jprintln(map[string]any{"status": "error", "message": "builder site not found for profile: " + profile + " — run 'next' first"})
+			return
+		}
+		switchSite(port)
+	}
+
 	// Git auto-commit and capture diff
 	var gitDiff string
 	gitStat, _ := shell(fmt.Sprintf("cd %s && git status --porcelain 2>/dev/null", wpContent))
@@ -431,6 +457,7 @@ func cmdVerify() {
 	}
 
 	if allPassed {
+		doCheckpointSave("latest")
 		db.Exec("DELETE FROM current_task WHERE id = 1")
 	}
 

--- a/cmd/wp-train/helpers.go
+++ b/cmd/wp-train/helpers.go
@@ -1,26 +1,30 @@
 package main
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	_ "modernc.org/sqlite"
 )
 
 const defaultPort = "10001"
 
 var (
 	homeDir      string
-	locwpBase    string // set dynamically per site port
+	mainPort     string // main training site port — DB lives here
+	sitePort     string // currently active wp-cli target port (may differ for builder sites)
+	locwpBase    string // set dynamically per active site port
 	wpRoot       string
 	wpContent    string
-	trainingDir  string
-	dbPath       string
+	trainingDir  string // always based on mainPort
+	dbPath       string // always based on mainPort
 	claudeDir    string // .claude/ directory (product root)
 	taskBankPath string
-	sitePort     string // locwp port, resolved at runtime
 )
 
 func init() {
@@ -30,27 +34,32 @@ func init() {
 	claudeDir = findClaudeDir()
 	taskBankPath = filepath.Join(claudeDir, "references", "task-bank.json") // legacy fallback only
 
-	// Resolve site port: try saved port from DB, else default
-	sitePort = resolveSitePort()
-	setSitePaths(sitePort)
+	// Resolve main site port and set training paths (DB always lives on main site)
+	mainPort = resolveMainPort()
+	setTrainingPaths(mainPort)
+	switchSite(mainPort)
 }
 
-// setSitePaths sets all path variables based on port.
-func setSitePaths(port string) {
-	locwpBase = filepath.Join(homeDir, ".locwp", "sites", port)
-	wpRoot = filepath.Join(locwpBase, "wordpress")
-	wpContent = filepath.Join(wpRoot, "wp-content")
-	trainingDir = filepath.Join(locwpBase, "training")
+// setTrainingPaths sets the training DB/data paths (always anchored to main site).
+func setTrainingPaths(port string) {
+	trainingDir = filepath.Join(homeDir, ".locwp", "sites", port, "training")
 	dbPath = filepath.Join(trainingDir, "wp-guider.db")
 }
 
-// resolveSitePort finds the training site port.
-// Priority: 1) WP_TRAIN_PORT env  2) saved in any existing DB  3) default 10001
-func resolveSitePort() string {
+// switchSite updates the active wp-cli target without touching trainingDir/dbPath.
+func switchSite(port string) {
+	sitePort = port
+	locwpBase = filepath.Join(homeDir, ".locwp", "sites", port)
+	wpRoot = filepath.Join(locwpBase, "wordpress")
+	wpContent = filepath.Join(wpRoot, "wp-content")
+}
+
+// resolveMainPort finds the main training site port.
+// Priority: 1) WP_TRAIN_PORT env  2) existing DB  3) default 10001
+func resolveMainPort() string {
 	if p := os.Getenv("WP_TRAIN_PORT"); p != "" {
 		return p
 	}
-	// Scan ~/.locwp/sites/*/training/wp-guider.db to find existing training site
 	sitesDir := filepath.Join(homeDir, ".locwp", "sites")
 	if entries, err := os.ReadDir(sitesDir); err == nil {
 		for _, e := range entries {
@@ -64,6 +73,176 @@ func resolveSitePort() string {
 		}
 	}
 	return defaultPort
+}
+
+// ── site map (multi-site port registry) ──────────────────────────────────────
+
+// SiteMap maps builder profile names to their locwp port numbers.
+type SiteMap struct {
+	Main      string  `json:"main"`
+	Elementor *string `json:"elementor"`
+	Zeroy     *string `json:"zeroy"`
+}
+
+func siteMapPath() string {
+	return filepath.Join(trainingDir, "sites.json")
+}
+
+func loadSiteMap() SiteMap {
+	data, err := os.ReadFile(siteMapPath())
+	if err != nil {
+		return SiteMap{Main: mainPort}
+	}
+	var sm SiteMap
+	if json.Unmarshal(data, &sm) != nil {
+		return SiteMap{Main: mainPort}
+	}
+	return sm
+}
+
+func saveSiteMap(sm SiteMap) {
+	os.MkdirAll(trainingDir, 0755)
+	data, _ := json.MarshalIndent(sm, "", "  ")
+	os.WriteFile(siteMapPath(), data, 0644)
+}
+
+// switchToCurrentTaskSite reads the active task from DB and switches sitePort
+// to the task's site profile. No-op if no active task or profile is "main".
+func switchToCurrentTaskSite() {
+	db, err := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(WAL)")
+	if err != nil {
+		return
+	}
+	defer db.Close()
+
+	var taskJSON string
+	if err := db.QueryRow("SELECT task_json FROM current_task WHERE id = 1").Scan(&taskJSON); err != nil {
+		return
+	}
+	var task map[string]any
+	if json.Unmarshal([]byte(taskJSON), &task) != nil {
+		return
+	}
+	profile, _ := task["site_profile"].(string)
+	if profile == "" || profile == "main" {
+		return
+	}
+	if port := portForProfile(profile); port != "" {
+		switchSite(port)
+	}
+}
+
+// profileForPort returns the site profile name for a given port.
+func profileForPort(port string) string {
+	sm := loadSiteMap()
+	if port == sm.Main {
+		return "main"
+	}
+	if sm.Elementor != nil && *sm.Elementor == port {
+		return "elementor"
+	}
+	if sm.Zeroy != nil && *sm.Zeroy == port {
+		return "zeroy"
+	}
+	return "main"
+}
+
+// portForProfile returns the locwp port for a site profile, or "" if not yet created.
+func portForProfile(profile string) string {
+	sm := loadSiteMap()
+	switch profile {
+	case "", "main":
+		return sm.Main
+	case "elementor":
+		if sm.Elementor != nil {
+			return *sm.Elementor
+		}
+	case "zeroy":
+		if sm.Zeroy != nil {
+			return *sm.Zeroy
+		}
+	}
+	return ""
+}
+
+// ensureBuilderSite returns the port for a builder profile, creating (forking from
+// main) if it doesn't exist yet. Returns the port and the site URL.
+func ensureBuilderSite(profile string) (string, error) {
+	if port := portForProfile(profile); port != "" {
+		return port, nil
+	}
+
+	log("Creating " + profile + " site (forking from main site " + mainPort + ")...")
+
+	// Create new locwp site
+	out, err := shell("locwp add --pass admin")
+	if err != nil {
+		return "", fmt.Errorf("locwp add failed: %s", out)
+	}
+	newPort := parsePort(out)
+	if newPort == "" {
+		return "", fmt.Errorf("could not determine port from locwp output: %s", out)
+	}
+
+	// Copy WordPress SQLite database from main site (inherits all settings/content)
+	srcDB := filepath.Join(homeDir, ".locwp", "sites", mainPort, "wordpress", "wp-content", "database", ".ht.sqlite")
+	dstDB := filepath.Join(homeDir, ".locwp", "sites", newPort, "wordpress", "wp-content", "database", ".ht.sqlite")
+	if fileExists(srcDB) {
+		log("Copying WordPress database...")
+		src, err := os.ReadFile(srcDB)
+		if err != nil {
+			return "", fmt.Errorf("failed to read main DB: %v", err)
+		}
+		if err := os.WriteFile(dstDB, src, 0644); err != nil {
+			return "", fmt.Errorf("failed to write builder DB: %v", err)
+		}
+	}
+
+	// Fix all URL references (wp search-replace handles serialized data correctly)
+	log("Updating URLs for new port...")
+	shellMust(fmt.Sprintf(
+		"locwp wp %s -- search-replace 'localhost:%s' 'localhost:%s' --all-tables --quiet",
+		newPort, mainPort, newPort,
+	))
+
+	// Initialize git tracking on new wp-content
+	newWpContent := filepath.Join(homeDir, ".locwp", "sites", newPort, "wordpress", "wp-content")
+	log("Initializing git in new wp-content...")
+	shellMust(fmt.Sprintf("cd %s && git init -q && git add -A && git commit -m baseline -q", newWpContent))
+
+	// Persist the new port to sites.json
+	sm := loadSiteMap()
+	switch profile {
+	case "elementor":
+		sm.Elementor = &newPort
+	case "zeroy":
+		sm.Zeroy = &newPort
+	}
+	saveSiteMap(sm)
+
+	log("Builder site ready on port " + newPort)
+	return newPort, nil
+}
+
+// parsePort extracts the port number from a "localhost:XXXXX" substring.
+func parsePort(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if idx := strings.Index(line, "localhost:"); idx >= 0 {
+			rest := line[idx+len("localhost:"):]
+			port := ""
+			for _, c := range rest {
+				if c >= '0' && c <= '9' {
+					port += string(c)
+				} else {
+					break
+				}
+			}
+			if port != "" {
+				return port
+			}
+		}
+	}
+	return ""
 }
 
 func findClaudeDir() string {

--- a/cmd/wp-train/taskbank.go
+++ b/cmd/wp-train/taskbank.go
@@ -18,6 +18,7 @@ type TopicEntry struct {
 
 type Task struct {
 	ID          string           `json:"id"`
+	SiteProfile string           `json:"site_profile,omitempty"`
 	Difficulty  int              `json:"difficulty"`
 	Description string           `json:"description"`
 	Verify      []map[string]any `json:"verify"`
@@ -64,12 +65,40 @@ func loadTaskBank() TaskBank {
 	return bank
 }
 
-// sortedKeys returns sorted topic keys.
+// topicOrder defines the canonical curriculum progression.
+// Topics not in this list fall to the end in alphabetical order.
+var topicOrder = []string{
+	// 基础设施
+	"domain", "hosting", "wp-install",
+	// 站点设置
+	"site-settings", "user-management",
+	// 内容管理
+	"pages", "media", "menus-nav", "posts-taxonomy",
+	// 外观定制 — theme 先，再 elementor，最后 zeroy
+	"theme", "elementor", "zeroy",
+	// 插件与扩展
+	"plugins-basic", "acf", "seo", "google-analytics",
+	// 运维与安全
+	"wp-config", "security", "backup-maintenance", "troubleshooting",
+}
+
+// sortedKeys returns topic keys in curriculum order.
 func sortedKeys(bank TaskBank) []string {
-	keys := make([]string, 0, len(bank))
-	for k := range bank {
-		keys = append(keys, k)
+	ordered := make([]string, 0, len(bank))
+	seen := make(map[string]bool)
+	for _, k := range topicOrder {
+		if _, ok := bank[k]; ok {
+			ordered = append(ordered, k)
+			seen[k] = true
+		}
 	}
-	sort.Strings(keys)
-	return keys
+	// Append any remaining keys alphabetically
+	var rest []string
+	for k := range bank {
+		if !seen[k] {
+			rest = append(rest, k)
+		}
+	}
+	sort.Strings(rest)
+	return append(ordered, rest...)
 }

--- a/cmd/wp-train/wp_train_test.go
+++ b/cmd/wp-train/wp_train_test.go
@@ -57,13 +57,14 @@ func TestLoadTaskBank(t *testing.T) {
 
 func TestSortedKeys(t *testing.T) {
 	bank := TaskBank{
-		"pages":         {Name: "b"},
-		"site-settings": {Name: "a"},
+		"pages":           {Name: "b"},
+		"site-settings":   {Name: "a"},
 		"user-management": {Name: "c"},
-		"media":         {Name: "d"},
+		"media":           {Name: "d"},
 	}
 	keys := sortedKeys(bank)
-	expected := []string{"media", "pages", "site-settings", "user-management"}
+	// Expected order matches topicOrder: site-settings, user-management, pages, media
+	expected := []string{"site-settings", "user-management", "pages", "media"}
 	for i, k := range keys {
 		if k != expected[i] {
 			t.Errorf("position %d: expected %q, got %q", i, expected[i], k)
@@ -220,17 +221,10 @@ func TestSelectNextTask(t *testing.T) {
 		"pages":           {Name: "Topic C", Tasks: []Task{{ID: "PG-1", Difficulty: 1}}},
 	}
 
-	// Should pick first sorted topic (pages)
+	// Curriculum order: site-settings → user-management → pages
 	topic, task := selectNextTask(db, bank)
-	if topic != "pages" || task.ID != "PG-1" {
-		t.Errorf("expected pages/PG-1, got %s/%s", topic, task.ID)
-	}
-
-	// Mark pages mastered → should pick site-settings
-	db.Exec("INSERT INTO topic_mastery (topic, consecutive_passes, mastered) VALUES ('pages', 2, 1)")
-	topic, task = selectNextTask(db, bank)
-	if topic != "site-settings" {
-		t.Errorf("expected site-settings, got %s", topic)
+	if topic != "site-settings" || task.ID != "SS-1" {
+		t.Errorf("expected site-settings/SS-1, got %s/%s", topic, task.ID)
 	}
 
 	// Mark site-settings mastered → should pick user-management
@@ -240,8 +234,15 @@ func TestSelectNextTask(t *testing.T) {
 		t.Errorf("expected user-management, got %s", topic)
 	}
 
-	// Mark all mastered → should return empty
+	// Mark user-management mastered → should pick pages
 	db.Exec("INSERT INTO topic_mastery (topic, consecutive_passes, mastered) VALUES ('user-management', 2, 1)")
+	topic, task = selectNextTask(db, bank)
+	if topic != "pages" {
+		t.Errorf("expected user-management, got %s", topic)
+	}
+
+	// Mark all mastered → should return empty
+	db.Exec("INSERT INTO topic_mastery (topic, consecutive_passes, mastered) VALUES ('pages', 2, 1)")
 	topic, task = selectNextTask(db, bank)
 	if topic != "" || task != nil {
 		t.Errorf("expected empty, got %s/%v", topic, task)

--- a/out/.claude/references/tasks/Elementor.json
+++ b/out/.claude/references/tasks/Elementor.json
@@ -4,6 +4,7 @@
     "tasks": [
       {
         "id": "ELE-1",
+        "site_profile": "elementor",
         "difficulty": 1,
         "description": "安装并激活 Elementor 插件（免费版）",
         "verify": [
@@ -19,6 +20,7 @@
       },
       {
         "id": "ELE-2",
+        "site_profile": "elementor",
         "difficulty": 1,
         "description": "安装并激活 Hello Elementor 主题（Elementor 官方极简主题）",
         "verify": [
@@ -35,6 +37,7 @@
       },
       {
         "id": "ELE-3",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "上传并激活 Elementor Pro 插件",
         "verify": [
@@ -51,6 +54,7 @@
       },
       {
         "id": "ELE-4",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "用 Theme Builder 创建自定义 Footer 模板：包含公司联系信息、快速链接、社交图标和版权声明",
         "verify": [
@@ -71,6 +75,7 @@
       },
       {
         "id": "ELE-5",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "创建 Single Post 模板（博客文章详情页模板）：包含 Post Title、Featured Image、Post Content、Author Box、Post Navigation",
         "verify": [
@@ -88,6 +93,7 @@
       },
       {
         "id": "ELE-6",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "创建 Archive 模板（文章列表页/分类页模板）：包含 Archive Title 和 Posts widget 展示文章列表",
         "verify": [
@@ -105,6 +111,7 @@
       },
       {
         "id": "ELE-7",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "在 Single Post 模板中使用 Dynamic Tags 读取 ACF 字段：添加一个 Heading widget，内容设为动态读取 ACF 的「副标题」字段",
         "verify": [
@@ -121,6 +128,7 @@
       },
       {
         "id": "ELE-8",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "创建一个用于展示 CPT（如 team_member）的 Single 模板：用 Dynamic Tags 映射 ACF 的 position、bio 字段",
         "verify": [
@@ -138,6 +146,7 @@
       },
       {
         "id": "ELE-9",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "用 Elementor Popup Builder 创建一个询盘弹窗：包含表单（Name + Email + Message），触发条件设为「点击按钮时弹出」",
         "verify": [
@@ -154,6 +163,7 @@
       },
       {
         "id": "ELE-10",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "创建一个 Landing Page：使用 Elementor Canvas 模板（无 Header/Footer），结构为 Hero → 产品特点 → 公司优势（Counter）→ 询盘表单",
         "verify": [
@@ -171,6 +181,7 @@
       },
       {
         "id": "ELE-11",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "将当前页面的某个区块保存为 Template，以便在其他页面复用",
         "verify": [
@@ -188,6 +199,7 @@
       },
       {
         "id": "ELE-12",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "从 Elementor 模板库（Template Library）导入一个预设模板到页面中",
         "verify": [
@@ -204,6 +216,7 @@
       },
       {
         "id": "ELE-13",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "用 Elementor 编辑 Home 页面，创建一个全宽 Container（Flexbox），方向设为 Row，内部放置一个 Heading widget 和一个 Button widget",
         "verify": [
@@ -225,6 +238,7 @@
       },
       {
         "id": "ELE-14",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "创建一个三列等宽布局：一个 Row Container 内嵌套三个 Column Container，每列放一个 Icon Box widget",
         "verify": [
@@ -241,6 +255,7 @@
       },
       {
         "id": "ELE-15",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "在页面中添加一个 Spacer widget（间距控件）和一个 Divider widget（分隔线），用于区分不同区块",
         "verify": [
@@ -258,6 +273,7 @@
       },
       {
         "id": "ELE-16",
+        "site_profile": "elementor",
         "difficulty": 1,
         "description": "在 Elementor 中添加一个 Image widget，上传一张图片并设置图片尺寸为 Large",
         "verify": [
@@ -274,6 +290,7 @@
       },
       {
         "id": "ELE-17",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "添加一个 Text Editor widget，写一段公司简介（至少 50 个英文单词）。设置字体大小为 16px，行高为 1.6",
         "verify": [
@@ -290,6 +307,7 @@
       },
       {
         "id": "ELE-18",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "添加一个 Button widget，文字为「Request a Quote」，链接到 /contact/ 页面，按钮样式设为实色填充",
         "verify": [
@@ -306,6 +324,7 @@
       },
       {
         "id": "ELE-19",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "在 Elementor 编辑器底部切换到 Tablet 和 Mobile 视图，调整 Heading widget 的字体大小：Desktop 40px、Tablet 28px、Mobile 22px",
         "verify": [
@@ -322,6 +341,7 @@
       },
       {
         "id": "ELE-20",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "设置某个 Container 在 Mobile 视图下隐藏（不在手机上显示）",
         "verify": [
@@ -338,6 +358,7 @@
       },
       {
         "id": "ELE-21",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "在 Elementor 的 Site Settings 中设置 Global Colors：Primary 色为 #2563EB（蓝色），Secondary 色为 #F59E0B（橙色），Text 色为 #1F2937",
         "verify": [
@@ -354,6 +375,7 @@
       },
       {
         "id": "ELE-22",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "在 Site Settings 中设置 Global Fonts：Primary 字体设为 Inter，Secondary 字体设为 Inter",
         "verify": [
@@ -370,6 +392,7 @@
       },
       {
         "id": "ELE-23",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "创建一个 Hero Section：全宽 Container + 背景图 + 深色叠加层（Overlay）+ 白色大标题 + 副标题 + CTA 按钮",
         "verify": [
@@ -388,6 +411,7 @@
       },
       {
         "id": "ELE-24",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "在 Hero Section 下方创建「服务/产品」展示区：三列 Icon Box，每列一个图标+标题+描述",
         "verify": [
@@ -406,6 +430,7 @@
       },
       {
         "id": "ELE-25",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "使用 Elementor Pro 的 Form widget 创建询盘表单：Name、Email、Company、Product Interest（下拉选择）、Message（文本域）",
         "verify": [
@@ -422,6 +447,7 @@
       },
       {
         "id": "ELE-26",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "配置表单的 Email 通知：收件人设为管理员邮箱，主题包含「New Inquiry from {field:name}」",
         "verify": [
@@ -438,6 +464,7 @@
       },
       {
         "id": "ELE-27",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "配置表单提交后跳转到 Thank You 页面",
         "verify": [
@@ -454,6 +481,7 @@
       },
       {
         "id": "ELE-28",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "添加 Counter widget 展示公司数据：如「15+ Years Experience」「500+ Projects」「50+ Countries」",
         "verify": [
@@ -470,6 +498,7 @@
       },
       {
         "id": "ELE-29",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "添加 Tabs 或 Accordion widget 展示产品分类或 FAQ 内容",
         "verify": [
@@ -486,6 +515,7 @@
       },
       {
         "id": "ELE-30",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "用 Elementor Theme Builder 创建自定义 Header 模板：Logo（左）+ Nav Menu（中）+ CTA Button（右），设置 Display Condition 为 Entire Site",
         "verify": [
@@ -506,6 +536,7 @@
       },
       {
         "id": "ELE-31",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "设置 Header 为 Sticky（固定在顶部，滚动时不消失）",
         "verify": [
@@ -522,6 +553,7 @@
       },
       {
         "id": "ELE-32",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "安装并配置 Elementor 的 Floating Buttons widget，设置 WhatsApp 联系按钮",
         "hints": [
@@ -538,6 +570,7 @@
       },
       {
         "id": "ELE-33",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "使用 Elementor Popup Builder 创建一个 Modal 类型弹窗，包含标题和关闭按钮",
         "hints": [
@@ -554,6 +587,7 @@
       },
       {
         "id": "ELE-34",
+        "site_profile": "elementor",
         "difficulty": 4,
         "description": "为弹窗设置触发条件：页面加载 5 秒后显示，且每个用户只显示一次",
         "hints": [
@@ -570,6 +604,7 @@
       },
       {
         "id": "ELE-35",
+        "site_profile": "elementor",
         "difficulty": 4,
         "description": "在弹窗中添加 Elementor Form widget 收集询盘信息",
         "hints": [
@@ -586,6 +621,7 @@
       },
       {
         "id": "ELE-36",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "用 Theme Builder 创建自定义 Header 模板：Logo + Nav Menu + 搜索图标",
         "hints": [
@@ -602,6 +638,7 @@
       },
       {
         "id": "ELE-37",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "用 Theme Builder 创建自定义 Footer 模板：公司信息 + 链接列表 + 版权声明",
         "hints": [
@@ -618,6 +655,7 @@
       },
       {
         "id": "ELE-38",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "用 Theme Builder 创建 Single Post 模板：Post Title + Featured Image + Post Content + Author Box",
         "hints": [
@@ -634,6 +672,7 @@
       },
       {
         "id": "ELE-39",
+        "site_profile": "elementor",
         "difficulty": 4,
         "description": "用 Theme Builder 创建 Archive 模板：归档标题 + Posts Widget 列表 + 分页",
         "hints": [
@@ -650,6 +689,7 @@
       },
       {
         "id": "ELE-40",
+        "site_profile": "elementor",
         "difficulty": 4,
         "description": "为 Header 模板设置 Display Conditions：所有页面显示，但排除 Landing Page",
         "hints": [
@@ -666,6 +706,7 @@
       },
       {
         "id": "ELE-41",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "用 Theme Builder 创建搜索结果页模板",
         "hints": [
@@ -682,6 +723,7 @@
       },
       {
         "id": "ELE-42",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "用 Theme Builder 创建 404 错误页面：包含提示文字和返回首页按钮",
         "hints": [
@@ -698,6 +740,7 @@
       },
       {
         "id": "ELE-43",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "在 Heading widget 中使用 Dynamic Tag 显示站点标题，在 Image widget 中使用 Dynamic Tag 显示文章特色图",
         "hints": [
@@ -714,6 +757,7 @@
       },
       {
         "id": "ELE-44",
+        "site_profile": "elementor",
         "difficulty": 4,
         "description": "将 ACF 自定义字段通过 Dynamic Tags 在 Elementor 模板中显示",
         "hints": [
@@ -730,6 +774,7 @@
       },
       {
         "id": "ELE-45",
+        "site_profile": "elementor",
         "difficulty": 4,
         "description": "添加 Posts Widget 展示最新文章，配置筛选条件和分页",
         "hints": [
@@ -746,6 +791,7 @@
       },
       {
         "id": "ELE-46",
+        "site_profile": "elementor",
         "difficulty": 4,
         "description": "添加 Portfolio Widget 展示作品集，配置悬停效果和筛选标签",
         "hints": [
@@ -762,6 +808,7 @@
       },
       {
         "id": "ELE-47",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "用 Theme Builder 创建 WooCommerce Single Product 模板",
         "hints": [
@@ -778,6 +825,7 @@
       },
       {
         "id": "ELE-48",
+        "site_profile": "elementor",
         "difficulty": 4,
         "description": "用 Theme Builder 创建 Products Archive 模板：商品网格 + 筛选",
         "hints": [
@@ -794,6 +842,7 @@
       },
       {
         "id": "ELE-49",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "创建一个 Landing Page：Canvas 模板 + Hero + 卖点 + CTA + 表单",
         "hints": [
@@ -810,6 +859,7 @@
       },
       {
         "id": "ELE-50",
+        "site_profile": "elementor",
         "difficulty": 4,
         "description": "学习 CTA 位置、对比测试思路。验证：将站点标题改为「CTA优化策略已掌握」",
         "hints": [
@@ -826,6 +876,7 @@
       },
       {
         "id": "ELE-51",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "将当前页面保存为 Elementor 模板，然后在另一个页面导入该模板",
         "hints": [
@@ -842,6 +893,7 @@
       },
       {
         "id": "ELE-52",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "将模板上传到 Elementor Cloud Library 实现跨站点复用",
         "hints": [
@@ -858,6 +910,7 @@
       },
       {
         "id": "ELE-53",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "创建可复用区块（Global Widget），修改后所有引用位置同步更新",
         "hints": [
@@ -874,6 +927,7 @@
       },
       {
         "id": "ELE-54",
+        "site_profile": "elementor",
         "difficulty": 2,
         "description": "使用 Elementor AI 功能为 Heading 或 Text widget 生成营销文案",
         "hints": [
@@ -890,6 +944,7 @@
       },
       {
         "id": "ELE-55",
+        "site_profile": "elementor",
         "difficulty": 3,
         "description": "使用 Elementor AI 生成或编辑图片并应用到页面",
         "hints": [
@@ -906,6 +961,7 @@
       },
       {
         "id": "ELE-56",
+        "site_profile": "elementor",
         "difficulty": 4,
         "description": "使用 Elementor AI 生成自定义 CSS 样式代码",
         "hints": [

--- a/out/.claude/references/tasks/ZeroY.json
+++ b/out/.claude/references/tasks/ZeroY.json
@@ -4,6 +4,7 @@
     "tasks": [
       {
         "id": "ZY-1",
+        "site_profile": "zeroy",
         "difficulty": 1,
         "description": "安装并激活 ZeroY 主题",
         "verify": [
@@ -20,6 +21,7 @@
       },
       {
         "id": "ZY-2",
+        "site_profile": "zeroy",
         "difficulty": 1,
         "description": "安装并激活 ZeroY 编辑器插件",
         "verify": [
@@ -36,6 +38,7 @@
       },
       {
         "id": "ZY-3",
+        "site_profile": "zeroy",
         "difficulty": 2,
         "description": "配置 ZeroY 的 AI 设置：填写业务上下文（About Your Business），描述你的公司和产品",
         "verify": [
@@ -53,6 +56,7 @@
       },
       {
         "id": "ZY-4",
+        "site_profile": "zeroy",
         "difficulty": 2,
         "description": "配置 ZeroY 的设计系统（Design System）：设置全局颜色和字体",
         "verify": [
@@ -70,6 +74,7 @@
       },
       {
         "id": "ZY-5",
+        "site_profile": "zeroy",
         "difficulty": 1,
         "description": "用 ZeroY 编辑器打开 Home 页面，使用 AI 生成功能创建首页内容",
         "verify": [
@@ -88,6 +93,7 @@
       },
       {
         "id": "ZY-6",
+        "site_profile": "zeroy",
         "difficulty": 2,
         "description": "用 ZeroY 编辑器修改 Home 页面中的某个区块内容（如修改标题文字或替换图片）",
         "verify": [
@@ -106,6 +112,7 @@
       },
       {
         "id": "ZY-7",
+        "site_profile": "zeroy",
         "difficulty": 2,
         "description": "用 ZeroY 为 About 页面生成内容，包含公司简介和团队信息",
         "verify": [
@@ -122,6 +129,7 @@
       },
       {
         "id": "ZY-8",
+        "site_profile": "zeroy",
         "difficulty": 2,
         "description": "用 ZeroY 为 Contact Us 页面生成内容，包含联系方式和询盘表单",
         "verify": [
@@ -138,6 +146,7 @@
       },
       {
         "id": "ZY-9",
+        "site_profile": "zeroy",
         "difficulty": 2,
         "description": "用 ZeroY 创建页眉（Header）动态模板：左边 Logo，中间导航，右边 CTA 按钮",
         "verify": [
@@ -157,6 +166,7 @@
       },
       {
         "id": "ZY-10",
+        "site_profile": "zeroy",
         "difficulty": 2,
         "description": "用 ZeroY 创建页脚（Footer）动态模板：包含公司信息、导航链接、WhatsApp 链接和版权声明",
         "verify": [
@@ -176,6 +186,7 @@
       },
       {
         "id": "ZY-11",
+        "site_profile": "zeroy",
         "difficulty": 2,
         "description": "用 ZeroY 创建 404 错误页面动态模板",
         "verify": [
@@ -193,6 +204,7 @@
       },
       {
         "id": "ZY-12",
+        "site_profile": "zeroy",
         "difficulty": 2,
         "description": "用 ZeroY 创建搜索结果页动态模板",
         "verify": [
@@ -210,6 +222,7 @@
       },
       {
         "id": "ZY-13",
+        "site_profile": "zeroy",
         "difficulty": 2,
         "description": "在页眉模板中设置导航菜单，包含二级下拉菜单（如 Product 下拉显示产品分类）",
         "verify": [
@@ -226,6 +239,7 @@
       },
       {
         "id": "ZY-14",
+        "site_profile": "zeroy",
         "difficulty": 3,
         "description": "用 ZeroY 创建一个询盘弹窗（Popup）：包含表单（姓名+邮箱+留言），设置触发条件",
         "verify": [
@@ -242,6 +256,7 @@
       },
       {
         "id": "ZY-15",
+        "site_profile": "zeroy",
         "difficulty": 2,
         "description": "配置询盘表单的提交后行为：跳转到 Thank You 页面，并发送邮件通知到管理员邮箱",
         "verify": [
@@ -259,6 +274,7 @@
       },
       {
         "id": "ZY-16",
+        "site_profile": "zeroy",
         "difficulty": 3,
         "description": "用 ZeroY 创建 404 错误页面模板",
         "hints": [
@@ -275,6 +291,7 @@
       },
       {
         "id": "ZY-17",
+        "site_profile": "zeroy",
         "difficulty": 3,
         "description": "用 ZeroY 创建搜索结果页模板",
         "hints": [
@@ -291,6 +308,7 @@
       },
       {
         "id": "ZY-18",
+        "site_profile": "zeroy",
         "difficulty": 4,
         "description": "用 ZeroY 创建文章归档页模板，展示分类下的文章列表",
         "hints": [
@@ -307,6 +325,7 @@
       },
       {
         "id": "ZY-19",
+        "site_profile": "zeroy",
         "difficulty": 4,
         "description": "用 ZeroY 创建单篇文章模板：标题 + 特色图 + 内容 + 作者信息",
         "hints": [
@@ -323,6 +342,7 @@
       },
       {
         "id": "ZY-20",
+        "site_profile": "zeroy",
         "difficulty": 2,
         "description": "进入 ZeroY → 表单提交，查看所有收到的询盘记录",
         "hints": [
@@ -339,6 +359,7 @@
       },
       {
         "id": "ZY-21",
+        "site_profile": "zeroy",
         "difficulty": 2,
         "description": "设置表单提交后跳转到 Thank You 感谢页面",
         "hints": [
@@ -355,6 +376,7 @@
       },
       {
         "id": "ZY-22",
+        "site_profile": "zeroy",
         "difficulty": 3,
         "description": "启用 wp_mail 邮件通知，设置收件人和邮件标题模板",
         "hints": [
@@ -371,6 +393,7 @@
       },
       {
         "id": "ZY-23",
+        "site_profile": "zeroy",
         "difficulty": 3,
         "description": "安装 WP Mail SMTP 插件解决邮件不稳定问题",
         "hints": [
@@ -387,6 +410,7 @@
       },
       {
         "id": "ZY-24",
+        "site_profile": "zeroy",
         "difficulty": 3,
         "description": "用 ZeroY 创建弹窗，设置触发条件（滚动/延时）",
         "hints": [
@@ -403,6 +427,7 @@
       },
       {
         "id": "ZY-25",
+        "site_profile": "zeroy",
         "difficulty": 3,
         "description": "在 Thank You 页面埋入 Google Ads 转化追踪代码",
         "hints": [
@@ -419,6 +444,7 @@
       },
       {
         "id": "ZY-26",
+        "site_profile": "zeroy",
         "difficulty": 3,
         "description": "通过 SEOPress/Yoast 配置 Google Analytics 和 Ads 全局代码",
         "hints": [
@@ -435,6 +461,7 @@
       },
       {
         "id": "ZY-27",
+        "site_profile": "zeroy",
         "difficulty": 3,
         "description": "用 ZeroY HTMX 实现文章列表的「加载更多」功能",
         "hints": [
@@ -451,6 +478,7 @@
       },
       {
         "id": "ZY-28",
+        "site_profile": "zeroy",
         "difficulty": 4,
         "description": "用 HTMX 实现搜索框实时搜索（keyup + 延迟请求）",
         "hints": [
@@ -467,6 +495,7 @@
       },
       {
         "id": "ZY-29",
+        "site_profile": "zeroy",
         "difficulty": 4,
         "description": "用 HTMX 实现按 ACF 分类法和字段值多条件筛选",
         "hints": [
@@ -483,6 +512,7 @@
       },
       {
         "id": "ZY-30",
+        "site_profile": "zeroy",
         "difficulty": 4,
         "description": "用 HTMX 实现无刷新分页功能",
         "hints": [
@@ -499,6 +529,7 @@
       },
       {
         "id": "ZY-31",
+        "site_profile": "zeroy",
         "difficulty": 4,
         "description": "用 HTMX 实现滚动到底部自动加载更多",
         "hints": [
@@ -515,6 +546,7 @@
       },
       {
         "id": "ZY-32",
+        "site_profile": "zeroy",
         "difficulty": 3,
         "description": "用 ZeroY 的 Swiper 组件创建自动播放轮播，配置导航箭头和分页点",
         "hints": [
@@ -531,6 +563,7 @@
       },
       {
         "id": "ZY-33",
+        "site_profile": "zeroy",
         "difficulty": 3,
         "description": "实现主图 + 缩略图联动的产品画廊效果",
         "hints": [
@@ -547,6 +580,7 @@
       },
       {
         "id": "ZY-34",
+        "site_profile": "zeroy",
         "difficulty": 4,
         "description": "实现响应式多卡片轮播（桌面 4 张、平板 2 张、手机 1 张）",
         "hints": [
@@ -563,6 +597,7 @@
       },
       {
         "id": "ZY-35",
+        "site_profile": "zeroy",
         "difficulty": 2,
         "description": "清除 Hostinger 的页面缓存、CDN 缓存和对象缓存",
         "hints": [
@@ -579,6 +614,7 @@
       },
       {
         "id": "ZY-36",
+        "site_profile": "zeroy",
         "difficulty": 2,
         "description": "学习 ZeroY 的 CSS 压缩设置：何时开启、何时关闭",
         "hints": [
@@ -595,6 +631,7 @@
       },
       {
         "id": "ZY-37",
+        "site_profile": "zeroy",
         "difficulty": 2,
         "description": "了解站点语言设置如何影响 AI 生成内容的语言",
         "hints": [
@@ -611,6 +648,7 @@
       },
       {
         "id": "ZY-38",
+        "site_profile": "zeroy",
         "difficulty": 3,
         "description": "排查表单提交后不跳转/不发邮件的问题（固定链接+SMTP+路径）",
         "hints": [
@@ -627,6 +665,7 @@
       },
       {
         "id": "ZY-39",
+        "site_profile": "zeroy",
         "difficulty": 3,
         "description": "排查 ZeroY AI 生成报错（400/401/403 状态码诊断）",
         "hints": [

--- a/out/.claude/skills/wp-checkpoint/SKILL.md
+++ b/out/.claude/skills/wp-checkpoint/SKILL.md
@@ -1,30 +1,36 @@
 ---
 name: wp-checkpoint
-description: 管理训练站点快照。保存、还原、列出检查点。当教练说"保存进度"、"还原"、"恢复"、"回退"、"checkpoint"时触发。
+description: 管理训练站点快照。保存、还原、列出检查点。当教练说"保存进度"、"还原"、"恢复"、"回退"、"恢复最新"、"checkpoint"时触发。
 ---
 
 # wp-checkpoint
 
-## 保存
+## 恢复到最新自动存档
+
+网站崩了或做爆了，一键恢复到上一次 wp-check 通过时的状态：
+
+```bash
+.claude/scripts/wp-train checkpoint restore-last
+```
+
+只恢复当前操作的站点（main / elementor / zeroy），不影响其他端口。
+
+## 保存手动检查点
 
 ```bash
 .claude/scripts/wp-train checkpoint save <name>
 ```
 
-保存当前数据库 + wp-content 文件 + wp-config.php。告诉教练检查点已保存。
-
-## 还原
+## 恢复指定检查点
 
 ```bash
 .claude/scripts/wp-train checkpoint restore <name>
 ```
 
-还原数据库、文件和配置到指定检查点。告诉教练站点已恢复。
-
-## 列出
+## 列出所有检查点
 
 ```bash
 .claude/scripts/wp-train checkpoint list
 ```
 
-返回所有检查点名称和创建时间。
+按站点分组显示所有存档名称和创建时间。

--- a/out/.claude/skills/wp-save/SKILL.md
+++ b/out/.claude/skills/wp-save/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: wp-save
+description: 手动保存或恢复当前站点的命名存档。只影响当前操作的端口，不影响其他站点。当教练说"存档"、"保存一个"、"wp-save"、"读档"、"恢复到 X"时触发。
+---
+
+# wp-save
+
+## 保存命名存档
+
+教练提供存档名（如 `homepage-done`），运行：
+
+```bash
+.claude/scripts/wp-train checkpoint save <name>
+```
+
+告诉教练已保存，存档名是什么，当前是哪个站点（端口）。
+
+## 恢复命名存档
+
+教练说恢复到某个存档名，运行：
+
+```bash
+.claude/scripts/wp-train checkpoint restore <name>
+```
+
+告诉教练站点已恢复到该存档。
+
+## 列出所有存档
+
+```bash
+.claude/scripts/wp-train checkpoint list
+```
+
+展示所有站点（main / elementor / zeroy）下的存档列表，包含创建时间。
+
+---
+
+**注意**：`latest` 是系统自动覆盖的存档（每次 wp-check 通过时更新），不建议手动操作。手动存档用自定义名字。


### PR DESCRIPTION
## Summary

> 依赖 #9，建议在 #9 合并后再合并本 PR

- `checkpointDir()` 按 site profile 分目录（`checkpoints/main/`、`checkpoints/elementor/`、`checkpoints/zeroy/`），各站点存档完全隔离
- `cmdVerify` 通过后自动覆盖保存 `latest/` checkpoint，零磁盘堆积
- 新增 `checkpoint restore-last`：一键恢复当前站点最近一次通过时的完整状态（WordPress DB + wp-content 文件 + wp-config）
- `cmdCheckpoint` 入口统一调 `switchToCurrentTaskSite()`，所有存档操作自动定位到正确端口
- `switchToCurrentTaskSite()` helper：从 DB 读 `current_task` 的 `site_profile`，调 `switchSite()` 切换
- `doCheckpointList` 改为按 profile 分组输出
- 新增 `wp-save` skill：用户手动命名存档、恢复指定存档、列出存档
- 更新 `wp-checkpoint` skill：补充 `restore-last` 用法

## Test plan

- [ ] `wp-train verify` 通过后 `checkpoints/{profile}/latest/` 自动创建
- [ ] 再次通过后 `latest/` 被覆盖，不新增目录
- [ ] `wp-train checkpoint restore-last` 恢复正确站点（elementor 任务 → 恢复 elementor/latest/）
- [ ] `wp-train checkpoint save myname` 创建命名存档，不影响 `latest/`
- [ ] `wp-train checkpoint list` 按 main/elementor/zeroy 分组显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)